### PR TITLE
Simplify playback API using Servant multiverb support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,7 @@
+packages: .
+
+source-repository-package
+    type: git
+    location: https://github.com/haskell-servant/servant
+    tag: 0d679b255080cdb97b4b3c3562ff90b282eec9b5
+    subdir: servant servant-client servant-client-core

--- a/lib/Spotify.hs
+++ b/lib/Spotify.hs
@@ -276,7 +276,7 @@ removeEpisodes :: (MonadSpotify m) => [EpisodeID] -> m ()
 removeEpisodes = noContent . inSpot . cli @RemoveEpisodes . SpotIDs
 
 getPlaybackState :: (MonadSpotify m) => m (Maybe PlaybackState)
-getPlaybackState = fmap handleAllJSONOrNoContent $ inSpot $ cli @GetPlaybackState marketFromToken $ Just "episode"
+getPlaybackState = inSpot . cli @GetPlaybackState marketFromToken $ Just "episode"
 transferPlayback :: (MonadSpotify m) => [DeviceID] -> Bool -> m ()
 transferPlayback device_ids play = noContent . inSpot $ cli @TransferPlayback TransferPlaybackBody{..}
 getAvailableDevices :: (MonadSpotify m) => m [Device]

--- a/servant/Spotify/Servant/Core.hs
+++ b/servant/Spotify/Servant/Core.hs
@@ -6,8 +6,6 @@ import Spotify.Types.Internal.CustomJSON
 import Spotify.Types.Misc
 
 import Data.Aeson (FromJSON, ToJSON)
-import Data.Aeson.Types (FromJSON (parseJSON))
-import Data.Data (Proxy (Proxy))
 import Data.HashMap.Strict qualified as HM
 import Data.Set (Set)
 import Data.Set qualified as Set
@@ -21,8 +19,6 @@ import Servant.API (
     Get,
     Header',
     JSON,
-    MimeUnrender,
-    OctetStream,
     Post,
     PostCreated,
     PostNoContent,
@@ -36,15 +32,10 @@ import Servant.API (
     StdMethod (GET),
     Strict,
     ToHttpApiData (toUrlPiece),
-    UVerb,
-    Union,
-    WithStatus (WithStatus),
-    mimeUnrender,
     type (:>),
  )
-import Servant.API.UVerb (foldMapUnion)
+import Servant.API.MultiVerb
 import Servant.HTML.Lucid (HTML)
-import Spotify.Types.Player
 import Web.FormUrlEncoded (Form (Form), ToForm (toForm))
 
 type Authorize =
@@ -99,6 +90,13 @@ type AuthHeader = Header' '[Strict, Required] "Authorization" AccessToken
 
 -- various patterns which appear throughout the API
 type SpotGet a = AuthHeader :> Get '[JSON] a
+type SpotGetOrNoContent a =
+    AuthHeader
+        :> MultiVerb
+            'GET
+            '[JSON]
+            '[RespondEmpty 204 "empty", Respond 200 "non-empty" a]
+            (Maybe a)
 type SpotPut a = AuthHeader :> Put '[JSON] a
 type SpotPutAccepted a = AuthHeader :> PutAccepted '[JSON] a
 type SpotPutNoContent = AuthHeader :> PutNoContent
@@ -122,29 +120,3 @@ type SpotPaging a =
 newtype ScopeSet = ScopeSet {unwrap :: Set Scope}
 instance ToHttpApiData ScopeSet where
     toUrlPiece = toUrlPiece . T.intercalate " " . map showScope . Set.toList . (.unwrap)
-
--- TODO this is all a rather elaborate workaround for limitations of `UVerb`
--- namely that the content-type can't depend on the return code
--- we'd like to just do something like:
--- `type SpotGetOrNoContent a = AuthHeader :> UVerb GET '[JSON, NoContent] '[WithStatus 200 a, WithStatus 204 NoContent]`
--- it's likely we could come up with a more opaque abstraction...
-type SpotGetOrNoContent a = AuthHeader :> UVerb GET '[JSON, OctetStream] '[WithStatus 200 (OctetStreamInstanceWrapper a), WithStatus 204 NoContent']
-data NoContent' = NoContent' deriving (Show)
-instance FromJSON NoContent' where
-    parseJSON _ = fail "dummy instance for SpotGetOrNoContent"
-newtype OctetStreamInstanceWrapper a = OctetStreamInstanceWrapper a
-    deriving newtype (FromJSON)
-instance MimeUnrender OctetStream (OctetStreamInstanceWrapper PlaybackState) where
-    mimeUnrender Proxy _ = Left "dummy instance for SpotGetOrNoContent"
-instance MimeUnrender OctetStream NoContent' where
-    mimeUnrender Proxy = \case
-        "" -> Right NoContent'
-        _ -> Left "unexpected content"
-class HandleJSONOrNoContent a b where
-    handleJSONOrNoContent :: b -> Maybe a
-instance HandleJSONOrNoContent a (WithStatus 200 (OctetStreamInstanceWrapper a)) where
-    handleJSONOrNoContent (WithStatus (OctetStreamInstanceWrapper b)) = Just b
-instance HandleJSONOrNoContent a (WithStatus 204 NoContent') where
-    handleJSONOrNoContent (WithStatus NoContent') = Nothing
-handleAllJSONOrNoContent :: forall a. Union '[WithStatus 200 (OctetStreamInstanceWrapper a), WithStatus 204 NoContent'] -> Maybe a
-handleAllJSONOrNoContent = foldMapUnion (Proxy @(HandleJSONOrNoContent a)) handleJSONOrNoContent

--- a/spotify.cabal
+++ b/spotify.cabal
@@ -102,9 +102,9 @@ library spotify-servant
         Orphans.Servant.Lucid
     build-depends:
         spotify-types,
+        generics-sop ^>= 0.5,
         http-api-data ^>= {0.4.3, 0.5, 0.6},
         servant-lucid ^>= 0.9,
-        sop-core ^>= 0.5,
 
 library
     import: common


### PR DESCRIPTION
This is quite beautiful. But we best not merge until a new Servant release is made which includes the feature (https://github.com/haskell-servant/servant/issues/1807), seeing as there are other changes I want to make to this project, and use in an app that interprets Servant API's via Miso, which won't add multiverb support until it's actually released...